### PR TITLE
Update README for new SQLite backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ VeronIA is a web-based chat interface designed for flexible interaction with mul
 
 ## Features
 
-The application allows users to select from various LLM providers, including OpenAI, Groq, and local models via Ollama. All conversations are automatically saved to a PostgreSQL database, enabling users to revisit, manage, and rename past dialogues. The interface is designed for a seamless and stateful chat experience, remembering conversation history and the selected model.
+The application allows users to select from various LLM providers, including OpenAI, Groq, and local models via Ollama. All conversations are automatically saved to a SQLite database (db/veronia.db), enabling users to revisit, manage, and rename past dialogues. The interface is designed for a seamless and stateful chat experience, remembering conversation history and the selected model.
 
 ## Technical Overview
 
-The project is built with Python and leverages Streamlit for the user interface. It uses the LangChain library for LLM abstraction, which simplifies communication with different model providers. For data persistence, it connects to a PostgreSQL database using the `psycopg` driver.
+The project is built with Python and leverages Streamlit for the user interface. It uses the LangChain library for LLM abstraction, which simplifies communication with different model providers. For data persistence, it uses a local SQLite database (`db/veronia.db`) accessed via Python's built-in `sqlite3` module.
 
 ## Setup and Installation
 
-To run this project locally, you will need Python 3.11+ and Poetry installed, as well as a running PostgreSQL server.
+To run this project locally, you will need Python 3.11+ and Poetry installed. A database server is not required because SQLite is used.
 
 1.  **Clone the repository**
 
@@ -31,34 +31,16 @@ To run this project locally, you will need Python 3.11+ and Poetry installed, as
 
 3.  **Configure Environment Variables**
 
-    Create a `.env` file in the root directory. This file will store your database credentials and API keys. Populate it based on the following structure:
+    Create a `.env` file in the root directory to store your LLM provider API keys:
 
-    ```
-    # PostgreSQL Database Configuration
-    POSTGRES_DB=your_db_name
-    POSTGRES_USER=your_db_user
-    POSTGRES_PASSWORD=your_db_password
-    POSTGRES_HOST=localhost
-    POSTGRES_PORT=5432
 
     # LLM Provider API Keys
     OPENAI_API_KEY="sk-..."
     GROQ_API_KEY="gsk_..."
     ```
 
-4.  **Database Setup**
+No manual database setup is required. The application uses a local SQLite database stored at `db/veronia.db`. The function `init_database()` will create the necessary tables on first run.
 
-    Before running the application, you must manually create the database and user role in PostgreSQL. The application will create the necessary tables on its first run, but not the database or the user.
-
-    Connect to your PostgreSQL instance (e.g., using `psql`) and run the following commands. Replace `your_db_name`, `your_db_user`, and `your_db_password` with the same values you will use in your `.env` file.
-
-    ```sql
-    CREATE DATABASE your_db_name;
-    CREATE USER your_db_user WITH PASSWORD 'your_db_password';
-    GRANT ALL PRIVILEGES ON DATABASE your_db_name TO your_db_user;
-    ```
-
-    **Note:** The project includes a script `db/init_db.py` for standalone table creation, but it is recommended to let the main application handle this automatically on startup.
 
 ## Running the Application
 


### PR DESCRIPTION
## Summary
- update database instructions in README to reflect new SQLite backend
- remove outdated PostgreSQL setup instructions
- note that `init_database()` creates tables automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686008aa21b08333b79484474227cf45