### PR TITLE
Clarify GPLv3 license in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ streamlit run app.py
 ```
 
 The application will be available in your web browser at the local address provided by Streamlit.
+
+## License
+
+This project is licensed under the terms of the GNU General Public License v3.0.
+See the [LICENSE](LICENSE) file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Interface simples para interações com mmodelos de LLM."
 authors = [
     {name = "Cláudio dos Santos",email = "cadossantos@proton.me"}
 ]
-license = {text = "MIT"}
+license = {text = "GPL-3.0-only"}
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 dependencies = [


### PR DESCRIPTION
## Summary
- set the project license to GPL-3.0-only in `pyproject.toml`
- mention the GPLv3 license in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686008af23e08333ab35aad9bbfc4d89